### PR TITLE
Stops an error in php 5.6.1

### DIFF
--- a/system/third_party/pvl_increment/pi.pvl_increment.php
+++ b/system/third_party/pvl_increment/pi.pvl_increment.php
@@ -114,7 +114,7 @@ class Pvl_increment
 	 *
 	 * @return string
 	 */
-	function usage()
+	public static function usage()
 	{
 			ob_start();
 


### PR DESCRIPTION
If this is not there, it gives an error/warning stating that it usage() cant be called statically.

"Non-static method If Pvl_increment::usage() should not be called statically, assuming $this from incompatible context"

I think I have done this correctly...
